### PR TITLE
Add cache to subscriptions count; update content when child changes

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -46,12 +46,12 @@ class Customer < ApplicationRecord
   
   # Returns true if the customer has open slots for subscription
   def open_slots?
-    subscriptions.count < slots
+    subscriptions.size < slots
   end
   
   # Returns number of available slow slots.
   def open_slots
-    slots - subscriptions.count
+    slots - subscriptions.size
   end
   
   # Returns true if the customer is already subscribed to the show

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -1,5 +1,5 @@
 class Episode < ApplicationRecord
-  belongs_to :show
+  belongs_to :show, touch: true
   has_one :video, as: :content
   has_many :favorites, as: :content, dependent: :destroy
   

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,5 +1,5 @@
 class Subscription < ApplicationRecord
-  belongs_to :customer
+  belongs_to :customer, counter_cache: true
   belongs_to :show
   validates :current_episode, numericality: { greater_than_or_equal_to: 0 }
   after_initialize :defaults_set

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -1,5 +1,5 @@
 class Video < ApplicationRecord
-  belongs_to :content, polymorphic: true
+  belongs_to :content, polymorphic: true, touch: true
   has_many :video_comments, dependent: :destroy
   has_one_attached :clip
   has_one_attached :thumbnail

--- a/db/migrate/20190423194825_add_counters_to_models.rb
+++ b/db/migrate/20190423194825_add_counters_to_models.rb
@@ -1,0 +1,5 @@
+class AddCountersToModels < ActiveRecord::Migration[5.2]
+  def change
+    add_column :customers, :subscriptions_count, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_23_034324) do
+ActiveRecord::Schema.define(version: 2019_04_23_194825) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2019_04_23_034324) do
     t.datetime "updated_at", null: false
     t.integer "slots"
     t.date "renewal_date"
+    t.integer "subscriptions_count"
   end
 
   create_table "episodes", force: :cascade do |t|


### PR DESCRIPTION
Add a counter for subscriptions for the customer.
Set video and episode to update parent object when updated itself. This can be used to properly sort by "recently updated"

Please comment if any other relationships should be updated when the child changes.